### PR TITLE
fix: basic모드가 unmount될때 accordian의 상태를 기억하지 못 하는 문제 해결

### DIFF
--- a/components/home/Desription/BasicMode/ScrollBarContent/index.tsx
+++ b/components/home/Desription/BasicMode/ScrollBarContent/index.tsx
@@ -3,13 +3,13 @@ import styled from "@emotion/styled";
 import ScrollBarContainer from "./ScrollBarContainer";
 import { responsiveSize } from "../../../../../lib/constants/size";
 import { useMobile } from "../../../../../hooks/DeviceType";
+import { useSetRecoilState } from "recoil";
+import { isAccordianOpenedState } from "../../../../../store";
 
-interface Props {
-  setIsAccordianOpened: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-function ScrollBarContent({ setIsAccordianOpened }: Props) {
+function ScrollBarContent() {
   const isMobile = useMobile();
+  const setIsAccordianOpened = useSetRecoilState(isAccordianOpenedState);
+
   return (
     <>
       <Styled.SpeedText>

--- a/components/home/Desription/BasicMode/index.tsx
+++ b/components/home/Desription/BasicMode/index.tsx
@@ -23,7 +23,7 @@ function BasicMode() {
         </Styled.ClosedAccordian>
       ) : (
         <>
-          <ScrollBarContent setIsAccordianOpened={setIsAccordianOpened} />
+          <ScrollBarContent />
           <SpeedContent />
         </>
       )}

--- a/components/home/Desription/BasicMode/index.tsx
+++ b/components/home/Desription/BasicMode/index.tsx
@@ -14,23 +14,6 @@ function BasicMode() {
     isAccordianOpenedState
   );
 
-  const isAccordianOpenedRef = useRef<boolean | null | undefined>(null);
-
-  useEffect(() => {
-    isAccordianOpenedRef.current = isAccordianOpened;
-  }, [isAccordianOpened]);
-
-  useEffect(() => {
-    setIsAccordianOpened(isAccordianOpenedRef.current);
-    return () => {
-      // isAccordianOpenedRef.current = isAccordianOpened;
-      // unMount시, state값인 isAccordianOpened는 가지고 올 수 없다.
-    };
-  }, []);
-  // 1. useState로 선언 시, 렌더링 시 매번 초기값으로 초기화되는 문제 -> isAccordianOpened를 recoil로 선언하였음.
-  // 2. isAccordianOpenedRef를 사용한 이유. Ref는 생명주기에 곤계없이, 계속 값을 유지하도록 해준다. useState는 생명주기를 타기 때문에, unMount시 값을 가지고 올 수 없는 문제.
-  // 3. isAccordianOpened이 변할때마다 Ref변수를 계속 업데이트해주고 있다. 컴포넌트가 unMount될때 한번만 업데이트해주면 좋을텐데, unMount될때듣 state값은 가지고 올 수 없는 상태이다.
-
   return (
     <Styled.Root>
       {isMobile && !isAccordianOpened ? (

--- a/components/home/Desription/BasicMode/index.tsx
+++ b/components/home/Desription/BasicMode/index.tsx
@@ -1,15 +1,36 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 
 import ScrollBarContent from "./ScrollBarContent";
 import SpeedContent from "./SpeedContent";
 import { responsiveSize } from "../../../../lib/constants/size";
 import { useMobile } from "../../../../hooks/DeviceType";
+import { useRecoilState } from "recoil";
+import { isAccordianOpenedState } from "../../../../store";
 
 function BasicMode() {
   const isMobile = useMobile();
-  const [isAccordianOpened, setIsAccordianOpened] = useState(false);
-  console.log(`isMobile`, isMobile);
+  const [isAccordianOpened, setIsAccordianOpened] = useRecoilState(
+    isAccordianOpenedState
+  );
+
+  const isAccordianOpenedRef = useRef<boolean | null | undefined>(null);
+
+  useEffect(() => {
+    isAccordianOpenedRef.current = isAccordianOpened;
+  }, [isAccordianOpened]);
+
+  useEffect(() => {
+    setIsAccordianOpened(isAccordianOpenedRef.current);
+    return () => {
+      // isAccordianOpenedRef.current = isAccordianOpened;
+      // unMount시, state값인 isAccordianOpened는 가지고 올 수 없다.
+    };
+  }, []);
+  // 1. useState로 선언 시, 렌더링 시 매번 초기값으로 초기화되는 문제 -> isAccordianOpened를 recoil로 선언하였음.
+  // 2. isAccordianOpenedRef를 사용한 이유. Ref는 생명주기에 곤계없이, 계속 값을 유지하도록 해준다. useState는 생명주기를 타기 때문에, unMount시 값을 가지고 올 수 없는 문제.
+  // 3. isAccordianOpened이 변할때마다 Ref변수를 계속 업데이트해주고 있다. 컴포넌트가 unMount될때 한번만 업데이트해주면 좋을텐데, unMount될때듣 state값은 가지고 올 수 없는 상태이다.
+
   return (
     <Styled.Root>
       {isMobile && !isAccordianOpened ? (

--- a/store/index.ts
+++ b/store/index.ts
@@ -34,3 +34,8 @@ export const textState = atom<string>({
   key: "textState",
   default: "",
 });
+
+export const isAccordianOpenedState = atom({
+  key: "isAccordianOpened",
+  default: false,
+});


### PR DESCRIPTION
- basic 모드에서 advanced 모드로 전환될때, 기존의 isAccordianOpened State 값을 기억하지 못 함.
- useState로 선언 시 매번 초기화되는 문제
- recoil 전역 변수를 사용


![image](https://user-images.githubusercontent.com/24906022/132135799-4f909b12-bed5-4595-b919-b9cc8cdbe5db.png)
